### PR TITLE
Minify in `scss` and `less` files

### DIFF
--- a/src/minifySelectionCommandProvider.ts
+++ b/src/minifySelectionCommandProvider.ts
@@ -14,6 +14,8 @@ function minifySelection(language: string) {
     let options = {};
     switch (language) {
         case "css":
+        case "scss":
+        case "less":
             options = {};
             let output = new CleanCSS(options).minify(selectedText);
             minified = output.styles;


### PR DESCRIPTION
Allow minifying selected text within SASS and LESS (`scss` and `less`) files